### PR TITLE
Make the environment variable behavior match with cli

### DIFF
--- a/table-tennis/README.md
+++ b/table-tennis/README.md
@@ -9,7 +9,7 @@ This is an application that stress-tests evently by creating thousands of realis
 2. Create an env file at the root of the module called `evently.env` with the following properties:
 
    ```shell
-   EVENTLY_URL=https://preview.evently.cloud
+   EVENTLY_BOOKMARK=https://preview.evently.cloud
    EVENTLY_ONLINE=true
    EVENTLY_TOKEN=<your-token-here>
    EVENTLY_RESET_LEDGER=false

--- a/table-tennis/src/evently/connect-evently.ts
+++ b/table-tennis/src/evently/connect-evently.ts
@@ -4,7 +4,7 @@ import {SendToEvently} from "./index"
 
 
 export function createEventlyConnection(poolSize: number): SendToEvently {
-  const urlPrefix = env("EVENTLY_URL")
+  const urlPrefix = env("EVENTLY_BOOKMARK", 'https://preview.evently.cloud')
 
   const authToken = `Bearer ${env("EVENTLY_TOKEN")}`
   console.info('Connecting to %s with Authorization: %s', urlPrefix, authToken)


### PR DESCRIPTION
Hey, realized I _really_ needed more test data. table-tennis seems to work great, but I wanted to match the environment variables for consistency (I define them in my root evently directory with 'direnv')
